### PR TITLE
install_sublime - replaced deprecated apt-key tool with new setup

### DIFF
--- a/pimpmykali.sh
+++ b/pimpmykali.sh
@@ -766,10 +766,14 @@ install_atom () {
     }
 
 install_sublime () {
-    echo -e "\n  $greenplus installing sublime text editor"
-    eval wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | sudo apt-key add -
+    secho -e "\n  $greenplus installing sublime text editor"
+    eval wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | gpg --no-default-keyring --keyring ./temp-keyring.gpg --import
+    eval gpg --no-default-keyring --keyring ./temp-keyring.gpg --export --output sublime-text.gpg
+    eval rm temp-keyring.gpg temp-keyring.gpg~
+    eval mkdir -p /usr/local/share/keyrings
+    eval mv ./sublime-text.gpg /usr/local/share/keyrings
     eval apt-get install apt-transport-https
-    eval echo "deb https://download.sublimetext.com/ apt/stable/" > /etc/apt/sources.list.d/sublime-text.list
+    eval echo "deb [signed-by=/usr/local/share/keyrings/sublime-text.gpg] https://download.sublimetext.com/ apt/stable/" > /etc/apt/sources.list.d/sublime-text.list
     apt_update && apt_update_complete
     eval apt -y install sublime-text
     }


### PR DESCRIPTION
```Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))```

Code has been modified according to the below solution, which lists a better way to handle the keys than directly adding to trusted.gpg.d

https://askubuntu.com/a/1307181

**Ref:**
https://syslog.me/2022/01/10/apt-key-is-deprecated-now-what/