### PR TITLE
With QEMU/LIBVIRT VMs that have XFCE, a script is required to enable auto screen resize with window resize.

### DIFF
--- a/pimpmykali.sh
+++ b/pimpmykali.sh
@@ -1234,13 +1234,12 @@ xfce_auto_res() {
       #      up using 50% of CPU (in the VM)
       res_script="#!/bin/bash
 monitor_count=$(xrandr --listactivemonitors | grep -c "Virtual")
-monitor=1
 while true; do
+  monitor=1
   while [ \$monitor -le \$monitor_count ]; do
       xrandr --output Virtual-\$monitor --auto
       let monitor++
   done
-  monitor=1
   sleep 1
 done"
 

--- a/pimpmykali.sh
+++ b/pimpmykali.sh
@@ -1236,7 +1236,7 @@ xfce_auto_res() {
 monitor_count=$(xrandr --listactivemonitors | grep -c "Virtual")
 while true; do
   monitor=1
-  while [ \$monitor -le \$monitor_count ]; do
+  while [ \"\$monitor\" -le \"\$monitor_count\" ]; do
       xrandr --output Virtual-\$monitor --auto
       let monitor++
   done


### PR DESCRIPTION
Since `pimpmykali.sh` detects QEMU VMs, I thought adding this feature would be useful.

On Linux guests running XFCE, the auto resize screen with window doesn't work automatically (Read more [here](https://stackoverflow.com/a/61540989/11442204)), you have to run the following command every time you resize the window:
```sh
xrandr --output Virtual-1 --auto
```
That's why I wrote this script:

```bash
#!/bin/bash
monitor_count=$(xrandr --listactivemonitors | grep -c "Virtual")
while true; do
  monitor=1
  while [ "$monitor" -le "$monitor_count" ]; do
      xrandr --output Virtual-\$monitor --auto
      let monitor++
  done
  sleep 1
done
```

After running this script, it works fine:

<image src="https://forum.manjaro.org/uploads/default/original/3X/1/2/125dd1ad81212d4fc357b68575729d19532e698a.gif"></image>

I looked into `crontab`, but `crontab` can’t run a command at less than 1 minute intervals. You can use `watch` by running the following command:
```bash
watch -n 1 xrandr --output Virtual-1 --auto
```
But I found it difficult to background the process, so I just stuck with my script, especially since it takes up ~hardly any~ no extra resources.



One more thing, I thing I might have found a more efficient way of finding the real user and their home directory:
```bash
# Real user, and real home directory
realuser=$(who | awk 'NR==1{print $1}')
realhome=$(getent passwd "$realuser" | cut -d: -f6)
```
This way, you don't need to repeat the whole set of commands twice in case the user is `root`.
Unless you purposely repeated the commands twice.

Anyway, I thought I'd share my ideas.