### PR TITLE
Fix peass-ng repository path

### DIFF
--- a/pimpmykali.sh
+++ b/pimpmykali.sh
@@ -510,8 +510,8 @@ fix_cme() {
 
 fix_linwinpeas() {
     # get all the peas!!!
-    current_build=$(curl -s https://github.com/carlospolop/PEASS-ng/releases | grep -i "refs/heads/master" -m 1 | awk '{ print $5 }' | cut -d "<" -f1)
-    releases_url="https://github.com/carlospolop/PEASS-ng/releases/download/$current_build"
+    current_build=$(curl -s https://github.com/peass-ng/PEASS-ng/releases | grep -i "refs/heads/master" -m 1 | awk '{ print $5 }' | cut -d "<" -f1)
+    releases_url="https://github.com/peass-ng/PEASS-ng/releases/download/$current_build"
 	  dest_linpeas="/opt/linpeas"
 	  dest_winpeas="/opt/winpeas"
     
@@ -534,8 +534,8 @@ fix_linwinpeas() {
      for winpeas_file in ${winpeas_arr[@]}; do
        echo -e "  $greenplus Downloading $winpeas_file to $dest_winpeas/$winpeas_file"
        # revision 1.7.4 static wget of the April 2023 release of Winpeas
-       # due to github issue https://github.com/carlospolop/PEASS-ng/issues/359 
-       wget -q https://github.com/carlospolop/PEASS-ng/releases/tag/20230419-b6aac9cb/$winpeas_file -O $dest_winpeas/$winpeas_file 
+       # due to github issue https://github.com/peass-ng/PEASS-ng/issues/359 
+       wget -q https://github.com/peass-ng/PEASS-ng/releases/tag/20230419-b6aac9cb/$winpeas_file -O $dest_winpeas/$winpeas_file 
        # original code to be re-enabled once the winpeas group releases a fixed self-contained version
        # wget -q $releases_url/$winpeas_file -O $dest_winpeas/$winpeas_file
        chmod +x $dest_winpeas/$winpeas_file 

--- a/pimpmykali.sh
+++ b/pimpmykali.sh
@@ -510,7 +510,7 @@ fix_cme() {
 
 fix_linwinpeas() {
     # get all the peas!!!
-    current_build=$(curl -s https://github.com/peass-ng/PEASS-ng/releases | grep -i "refs/heads/master" -m 1 | awk '{ print $5 }' | cut -d "<" -f1)
+    current_build=$(curl -s -L https://github.com/peass-ng/PEASS-ng/releases | grep -i "refs/heads/master" -m 1 | awk '{ print $5 }' | cut -d "<" -f1)
     releases_url="https://github.com/peass-ng/PEASS-ng/releases/download/$current_build"
 	  dest_linpeas="/opt/linpeas"
 	  dest_winpeas="/opt/winpeas"


### PR DESCRIPTION
The link used to get the binaries was pointing to the "carlospolop" github account. It seems this got renamed or moved to a different account "peass-ng". You can check this by opening https://github.com/carlospolop/PEASS-ng/ and checking the redirection target URL.

I've noticed that the part of the script that pulls these files was downloading empty files. 
![image](https://github.com/Dewalt-arch/pimpmykali/assets/3900123/509b93f3-a786-4303-8ab5-d3eeb2bc4ba0)

After making the changes in this PR, the files download correctly.
<img width="550" alt="image" src="https://github.com/Dewalt-arch/pimpmykali/assets/3900123/30931bff-c092-4fbf-a228-41ac18a1b0e9">
