### PR TITLE
Update pimpmykali.sh

### DIFF
--- a/pimpmykali.sh
+++ b/pimpmykali.sh
@@ -1834,7 +1834,7 @@ install_vscode() {
     is_installed "wget gpg apt_transport_https"
 
     wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-    sudo install -D -o root -g root -m 644 microsoft.gpg /usr/share/keyrings/packages.microsoft.gpg
+    sudo install -D -o root -g root -m 644 microsoft.gpg /usr/share/keyrings/microsoft.gpg
 	echo "Types: deb\nURIs: https://packages.microsoft.com/repos/code\nSuites: stable\nComponents: main\nArchitectures: amd64,arm64,armhf\nSigned-By: /usr/share/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/vscode.sources > /dev/null
     rm -f microsoft.gpg
     #required-apt-update

--- a/pimpmykali.sh
+++ b/pimpmykali.sh
@@ -1833,10 +1833,10 @@ install_vscode() {
 
     is_installed "wget gpg apt_transport_https"
 
-    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-    sudo install -D -o root -g root -m 644 microsoft.gpg /usr/share/keyrings/microsoft.gpg
-	echo "Types: deb\nURIs: https://packages.microsoft.com/repos/code\nSuites: stable\nComponents: main\nArchitectures: amd64,arm64,armhf\nSigned-By: /usr/share/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/vscode.sources > /dev/null
-    rm -f microsoft.gpg
+    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/packages.microsoft.gpg
+    sudo install -D -o root -g root -m 644 /tmp/packages.microsoft.gpg /etc/apt/keyrings/packages.microsoft.gpg
+	echo "Types: deb\nURIs: https://packages.microsoft.com/repos/code\nSuites: stable\nComponents: main\nArchitectures: amd64,arm64,armhf\nSigned-By: /etc/apt/keyrings/packages.microsoft.gpg" | sudo tee /etc/apt/sources.list.d/vscode.sources > /dev/null
+    rm -f /tmp/packages.microsoft.gpg
     #required-apt-update
     apt_update
     is_installed code

--- a/pimpmykali.sh
+++ b/pimpmykali.sh
@@ -1835,6 +1835,7 @@ install_vscode() {
 
     wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
     sudo install -D -o root -g root -m 644 microsoft.gpg /usr/share/keyrings/microsoft.gpg
+	echo "Types: deb\nURIs: https://packages.microsoft.com/repos/code\nSuites: stable\nComponents: main\nArchitectures: amd64,arm64,armhf\nSigned-By: /usr/share/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/vscode.sources > /dev/null
     rm -f microsoft.gpg
     #required-apt-update
     apt_update

--- a/pimpmykali.sh
+++ b/pimpmykali.sh
@@ -1833,10 +1833,10 @@ install_vscode() {
 
     is_installed "wget gpg apt_transport_https"
 
-    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/packages.microsoft.gpg
-    sudo install -D -o root -g root -m 644 /tmp/packages.microsoft.gpg /etc/apt/keyrings/packages.microsoft.gpg
-	echo "Types: deb\nURIs: https://packages.microsoft.com/repos/code\nSuites: stable\nComponents: main\nArchitectures: amd64,arm64,armhf\nSigned-By: /etc/apt/keyrings/packages.microsoft.gpg" | sudo tee /etc/apt/sources.list.d/vscode.sources > /dev/null
-    rm -f /tmp/packages.microsoft.gpg
+    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+    sudo install -D -o root -g root -m 644 microsoft.gpg /usr/share/keyrings/packages.microsoft.gpg
+	echo "Types: deb\nURIs: https://packages.microsoft.com/repos/code\nSuites: stable\nComponents: main\nArchitectures: amd64,arm64,armhf\nSigned-By: /usr/share/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/vscode.sources > /dev/null
+    rm -f microsoft.gpg
     #required-apt-update
     apt_update
     is_installed code

--- a/pimpmykali.sh
+++ b/pimpmykali.sh
@@ -1833,10 +1833,9 @@ install_vscode() {
 
     is_installed "wget gpg apt_transport_https"
 
-    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/packages.microsoft.gpg
-    sudo install -D -o root -g root -m 644 /tmp/packages.microsoft.gpg /etc/apt/keyrings/packages.microsoft.gpg
-    echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" | sudo tee /etc/apt/sources.list.d/vscode.list > /dev/null
-    rm -f /tmp/packages.microsoft.gpg
+    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+    sudo install -D -o root -g root -m 644 microsoft.gpg /usr/share/keyrings/microsoft.gpg
+    rm -f microsoft.gpg
     #required-apt-update
     apt_update
     is_installed code


### PR DESCRIPTION
Fixed VSCode installation steps according to the official documentation (https://code.visualstudio.com/docs/setup/linux#_install-vs-code-on-linux) and in response to https://github.com/Dewalt-arch/pimpmykali/issues/59.